### PR TITLE
Renamed and Fixed Syntax

### DIFF
--- a/PSDeploy.ps1
+++ b/PSDeploy.ps1
@@ -4,13 +4,13 @@ if($Env:BuildSystems -eq 'AppVeyor' -and $Env:BranchName -in @('DEV','PROD')) {
 elseif($Env:USERDOMAIN -eq 'CONTOSO' -and $Env:BranchName -in @('DEV','PROD')) {
     # How you can move MOFs and Zipped modules for DSC PULL to a file share
     Deploy DeployMofs {
-        ByFileSystem {
+        By FileSystem {
             FromSource 'BuildOutput\MOF'
             To '\\contoso\dfs\DSC\MOF'
         }
     }
     Deploy DeployMofs {
-        ByFileSystem {
+        By FileSystem {
             FromSource 'BuildOutput\DscModules'
             To '\\contoso\dfs\DSC\DscModules'
         }


### PR DESCRIPTION
- Renamed because `Invoke-PSDeploy` [looks for](https://github.com/RamblingCookieMonster/PSDeploy#deployments): `*.*Deploy.ps1` or `*PSDeploy.ps1`.
- Syntax: `ByFileSystem` should be two words:  `By FileSystem`