### PR TITLE
Call module variable directly instead of *-PSTopConfigurationName

### DIFF
--- a/RootConfiguration.ps1
+++ b/RootConfiguration.ps1
@@ -10,10 +10,10 @@ configuration "RootConfiguration"
     Import-DscResource -ModuleName SharedDscConfig -ModuleVersion 0.0.4
 
     $module = Get-Module PSDesiredStateConfiguration
-    $null = & $module {param($tag,$Env) Set-PSTopConfigurationName "MOF_$($Env)_$($tag)"} "$BuildVersion",$Environment
+    & $module {param($tag,$Env) $Script:PSTopConfigurationName = "MOF_$($Env)_$($tag)"} "$BuildVersion",$Environment
 
     node $ConfigurationData.AllNodes.NodeName {
-        Write-Host "`r`n$('-'*75)`r`n$($Node.Name) : $($Node.NodeName) : $(&$module { Get-PSTopConfigurationName })" -ForegroundColor Yellow
+        Write-Host "`r`n$('-'*75)`r`n$($Node.Name) : $($Node.NodeName) : $(& $module { $Script:PSTopConfigurationName })" -ForegroundColor Yellow
         $env:PSModulePath = $goodPSModulePath
         (Lookup 'Configurations').Foreach{
             $configurationName = $_


### PR DESCRIPTION
Fixes #19 

Sorry for submitting a PR before waiting for your response. If this is not the fix you want, don't hesitate to just close the PR. 

Thanks for a Datum, it's a great tool!