### PR TITLE
Make Packages part of the SoftwareBase config

### DIFF
--- a/DSC_ConfigData/Roles/WindowsBase.yml
+++ b/DSC_ConfigData/Roles/WindowsBase.yml
@@ -12,7 +12,7 @@ SoftwareBase:
       Disabled: false
       Source: https://chocolatey.org/api/v2
 
-Packages:
-  - Name: chocolatey
-  - Name: NotepadPlusplus
-  - Name: Putty
+  Packages:
+    - Name: chocolatey
+    - Name: NotepadPlusplus
+    - Name: Putty


### PR DESCRIPTION
Packages are not being correctly pulled through into the resulting config because they aren't declared as a Configuration but actually need to be part of the SoftwareBase configuration. Fixing the indenting solves this problem and generates the expected MOF and RSOP.